### PR TITLE
Update minimatch to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configurify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Browserify transform to expose configuration to the browser",
   "author": "Felix Gnass <fgnass@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,18 +5,20 @@
   "author": "Felix Gnass <fgnass@gmail.com>",
   "license": "MIT",
   "keywords": [
-    "browserify", "browserify-transform", "configuration"
+    "browserify",
+    "browserify-transform",
+    "configuration"
   ],
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/fgnass/configurify.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/fgnass/configurify.git"
   },
   "main": "index.js",
   "scripts": {
     "test": "node test"
   },
   "dependencies": {
-    "minimatch": "^1.0.0",
+    "minimatch": "^3.0.3",
     "through2": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR brings the version of minimatch up to ^3.0.0, to avoid a potential [security problem](https://nodesecurity.io/advisories/118) with minimatch@1.0.0.